### PR TITLE
Add redirecting 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>404 - Not Found</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:;" />
+  <link rel="stylesheet" href="style/style.css" />
+  <script>
+    (function() {
+      // Redirect to index.html preserving the path as a hash for client-side routing
+      var base = '/my-microsite';
+      var path = window.location.pathname;
+      if (path.startsWith(base)) {
+        path = path.slice(base.length);
+      }
+      var newUrl = base + '/#' + path + window.location.search + window.location.hash;
+      window.location.replace(newUrl);
+    })();
+  </script>
+</head>
+<body>
+  <div class="container">
+    <h1>404 - Page Not Found</h1>
+    <p>Redirecting you to the microsite...</p>
+  </div>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository hosts a simple microsite used to publish my newsletter. The landing page lists available newsletter issues.
 
 * `index.html` – landing page with a list of newsletters
+* `404.html` – redirect helper so deep links work on GitHub Pages
 * `vol1.html` – first newsletter issue
 * `vol2.html` – education roadmap with a light-themed, interactive D3.js Sankey chart
 


### PR DESCRIPTION
## Summary
- add `404.html` with script that redirects deep links to index using hash-based routing
- mention new 404 helper in README

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d2f9f7ac8333a8678f240e9a9763